### PR TITLE
fix: Policy violation remediation in test-workloads/hostpath-deployment.yaml

### DIFF
--- a/test-workloads/hostpath-deployment.yaml
+++ b/test-workloads/hostpath-deployment.yaml
@@ -30,6 +30,4 @@ spec:
             memory: 256Mi
       volumes:
       - name: host-volume
-        hostPath:  # This violates disallow-host-path policy
-          path: /var/lib
-          type: Directory
+        emptyDir: {}


### PR DESCRIPTION
## Policy Violation Remediation

**File:** test-workloads/hostpath-deployment.yaml
**Explanation:** Replaced the hostPath volume with an emptyDir volume to comply with the disallow-host-path policy. The hostPath volume type poses security risks by allowing containers to access the host filesystem. The emptyDir volume provides a safe alternative that creates a temporary directory within the pod's lifecycle without accessing the host filesystem.