### PR TITLE
fix: Policy violation remediation in test-workloads/hostports-deployment.yaml

### DIFF
--- a/test-workloads/hostports-deployment.yaml
+++ b/test-workloads/hostports-deployment.yaml
@@ -20,7 +20,6 @@ spec:
         image: nginx:1.20
         ports:
         - containerPort: 80
-          hostPort: 8080  # This violates disallow-host-ports policy
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Policy Violation Remediation

**File:** test-workloads/hostports-deployment.yaml
**Explanation:** Removed the hostPort configuration from the container port specification to comply with the disallow-host-ports policy. The container will still expose port 80 internally within the cluster, but will no longer bind to host port 8080. This eliminates the security risk of exposing container ports directly on the host network interface.