### PR TITLE
fix: Policy violation remediation in test-workloads/capabilities-deployment.yaml

### DIFF
--- a/test-workloads/capabilities-deployment.yaml
+++ b/test-workloads/capabilities-deployment.yaml
@@ -20,8 +20,6 @@ spec:
         image: nginx:1.20
         securityContext:
           capabilities:
-            drop:
-            - ALL
         resources:
           requests:
             cpu: 100m

--- a/test-workloads/capabilities-deployment.yaml
+++ b/test-workloads/capabilities-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         image: nginx:1.20
         securityContext:
           capabilities:
+            drop:
+            - ALL
         resources:
           requests:
             cpu: 100m

--- a/test-workloads/capabilities-deployment.yaml
+++ b/test-workloads/capabilities-deployment.yaml
@@ -20,9 +20,8 @@ spec:
         image: nginx:1.20
         securityContext:
           capabilities:
-            add:
-            - SYS_ADMIN  # This violates disallow-capabilities policy
-            - NET_ADMIN
+            drop:
+            - ALL
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Policy Violation Remediation

**File:** test-workloads/capabilities-deployment.yaml
**Explanation:** Removed the 'add' capabilities section that contained SYS_ADMIN and NET_ADMIN capabilities, and replaced it with 'drop: [ALL]' to ensure no capabilities are added. This follows security best practices by dropping all capabilities by default, which complies with the disallow-capabilities policy that prevents adding potentially dangerous capabilities to containers.