### PR TITLE
fix: Policy violation remediation in test-workloads/seccomp-deployment.yaml

### DIFF
--- a/test-workloads/seccomp-deployment.yaml
+++ b/test-workloads/seccomp-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         image: nginx:1.20
         securityContext:
           seccompProfile:
-            type: Unconfined  # This violates restrict-seccomp policy
+            type: RuntimeDefault
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Policy Violation Remediation

**File:** test-workloads/seccomp-deployment.yaml
**Explanation:** Remediated seccomp profile violation by changing the seccompProfile type from 'Unconfined' to 'RuntimeDefault'. The 'Unconfined' type disables seccomp filtering entirely, which poses security risks. 'RuntimeDefault' applies the container runtime's default seccomp profile, providing appropriate security filtering while maintaining compatibility.