### PR TITLE
fix: Policy violation remediation in test-workloads/hostnamespaces-deployment.yaml

### DIFF
--- a/test-workloads/hostnamespaces-deployment.yaml
+++ b/test-workloads/hostnamespaces-deployment.yaml
@@ -15,9 +15,6 @@ spec:
       labels:
         app: hostnamespaces-test
     spec:
-      hostNetwork: true  # This violates disallow-host-namespaces policy
-      hostPID: true      # This also violates disallow-host-namespaces policy
-      hostIPC: true      # This also violates disallow-host-namespaces policy
       containers:
       - name: hostnamespaces-container
         image: nginx:1.20


### PR DESCRIPTION
## Policy Violation Remediation

**File:** test-workloads/hostnamespaces-deployment.yaml
**Explanation:** Removed hostNetwork, hostPID, and hostIPC fields from the pod spec as they violate the disallow-host-namespaces policy. These fields allow containers to share the host's network, process, and IPC namespaces respectively, which poses security risks. The deployment will now run with isolated namespaces, which is the secure default behavior.