### PR TITLE
fix: Policy violation remediation in test-workloads/hostpath-deployment.yaml

### DIFF
--- a/test-workloads/hostpath-deployment.yaml
+++ b/test-workloads/hostpath-deployment.yaml
@@ -17,15 +17,13 @@ spec:
     spec:
       volumes:
       - name: host-volume
-        hostPath:
-          path: /var/run/docker.sock  # This violates disallow-host-path policy
-          type: Socket
+        emptyDir: {}
       containers:
       - name: hostpath-container
         image: nginx:1.20
         volumeMounts:
         - name: host-volume
-          mountPath: /host/var/run/docker.sock
+          mountPath: /tmp/volume
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Policy Violation Remediation

**File:** test-workloads/hostpath-deployment.yaml
**Explanation:** Replaced the hostPath volume with an emptyDir volume to comply with the disallow-host-path policy. Changed the mount path from '/host/var/run/docker.sock' to '/tmp/volume' since the original path was specific to the Docker socket which is no longer available. The emptyDir volume provides a safe, temporary storage location that doesn't violate security policies.