### PR TITLE
fix: Policy violation remediation in test-workloads/hostports-deployment.yaml

### DIFF
--- a/test-workloads/hostports-deployment.yaml
+++ b/test-workloads/hostports-deployment.yaml
@@ -23,4 +23,3 @@ spec:
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 8080  # VIOLATION: hostPort bypasses network security


### PR DESCRIPTION
## Policy Violation Remediation

**File:** test-workloads/hostports-deployment.yaml
**Explanation:** Removed the hostPort configuration from the container port specification to comply with the disallow-host-ports policy. The hostPort field bypasses Kubernetes network policies and creates security vulnerabilities by directly exposing container ports on the host network. The containerPort (80) is retained for internal cluster communication. To expose this service externally, consider creating a Service resource with type ClusterIP, NodePort, or LoadBalancer instead of using hostPort.